### PR TITLE
fix(issues): resolve names to node IDs in createIssue/updateIssue

### DIFF
--- a/src/__tests__/unit/infrastructure/github/repositories/GitHubIssueRepository.test.ts
+++ b/src/__tests__/unit/infrastructure/github/repositories/GitHubIssueRepository.test.ts
@@ -45,4 +45,84 @@ describe("GitHubIssueRepository", () => {
   it("should create an instance correctly", () => {
     expect(repository).toBeDefined();
   });
+
+  describe("create", () => {
+    // Routes each GraphQL call by its content, so the assertions below can
+    // inspect exactly what ends up in the mutation input.
+    const stubGraphql = () => {
+      (mockOctokit.graphql as any).mockImplementation((query: string) => {
+        if (query.includes("GetRepositoryNodeId")) {
+          return Promise.resolve({ repository: { id: "R_repo123" } });
+        }
+        if (query.includes("GetLabelIds")) {
+          return Promise.resolve({
+            repository: { labels: { nodes: [{ id: "LA_bug", name: "bug" }] } },
+          });
+        }
+        if (query.includes("GetAssigneeIds")) {
+          return Promise.resolve({
+            repository: {
+              assignableUsers: { nodes: [{ id: "U_alice", login: "alice" }] },
+            },
+          });
+        }
+        return Promise.resolve({
+          createIssue: {
+            issue: {
+              id: "I_1",
+              number: 1,
+              title: "Test",
+              body: "Body",
+              state: "OPEN",
+              createdAt: "2025-01-01T00:00:00Z",
+              updatedAt: "2025-01-01T00:00:00Z",
+              assignees: { nodes: [{ login: "alice" }] },
+              labels: { nodes: [{ name: "bug" }] },
+              milestone: null,
+            },
+          },
+        });
+      });
+    };
+
+    const mutationInput = () => {
+      const call = (mockOctokit.graphql as any).mock.calls.find(
+        ([query]: [string]) => query.includes("createIssue")
+      );
+      return call?.[1]?.input;
+    };
+
+    it("passes node IDs — not names — to createIssue", async () => {
+      stubGraphql();
+
+      await repository.create({
+        title: "Test",
+        description: "Body",
+        labels: ["bug"],
+        assignees: ["alice"],
+      });
+
+      // Regression guard: passing names here makes GitHub reject the mutation
+      // with "Could not resolve to a node with the global id of '<name>'".
+      expect(mutationInput()).toEqual(
+        expect.objectContaining({
+          repositoryId: "R_repo123",
+          labelIds: ["LA_bug"],
+          assigneeIds: ["U_alice"],
+        })
+      );
+    });
+
+    it("skips labels that do not exist instead of failing", async () => {
+      stubGraphql();
+
+      await repository.create({
+        title: "Test",
+        description: "Body",
+        labels: ["bug", "does-not-exist"],
+      });
+
+      expect(mutationInput().labelIds).toEqual(["LA_bug"]);
+    });
+  });
 });

--- a/src/infrastructure/github/repositories/BaseRepository.ts
+++ b/src/infrastructure/github/repositories/BaseRepository.ts
@@ -16,6 +16,7 @@ export abstract class BaseGitHubRepository implements IGitHubRepository {
   protected readonly retryAttempts: number = 3;
   protected readonly apiUtil: GitHubApiUtil;
   protected readonly logger: ILogger;
+  private repositoryNodeId?: string;
 
   constructor(
     public readonly octokit: OctokitInstance,
@@ -171,6 +172,131 @@ export abstract class BaseGitHubRepository implements IGitHubRepository {
     }
 
     return response.repository.issue.id;
+  }
+
+  /**
+   * Resolve the repository's node ID.
+   *
+   * `CreateIssueInput.repositoryId` is an `ID!`, not a repository name.
+   *
+   * Cached for the lifetime of the instance — a repository's node ID is stable.
+   *
+   * @returns The node ID of the configured repository
+   * @throws Error if the repository is not found
+   */
+  protected async resolveRepositoryNodeId(): Promise<string> {
+    if (this.repositoryNodeId) return this.repositoryNodeId;
+
+    const query = `
+      query GetRepositoryNodeId($owner: String!, $repo: String!) {
+        repository(owner: $owner, name: $repo) {
+          id
+        }
+      }
+    `;
+
+    interface RepositoryNodeIdResponse {
+      repository: { id: string } | null;
+    }
+
+    const response = await this.graphql<RepositoryNodeIdResponse>(query, {});
+
+    if (!response.repository) {
+      throw new Error(`Repository ${this.owner}/${this.repo} not found`);
+    }
+
+    this.repositoryNodeId = response.repository.id;
+    return this.repositoryNodeId;
+  }
+
+  /**
+   * Resolve label names to node IDs.
+   *
+   * `CreateIssueInput.labelIds` / `UpdateIssueInput.labelIds` are `[ID!]`, so
+   * passing names produces `Could not resolve to a node with the global id of '<name>'`.
+   *
+   * Labels that do not exist in the repository are skipped with a warning rather
+   * than created — creating them would silently alter the repository's label
+   * taxonomy as a side effect of writing an issue.
+   *
+   * Deliberately not cached: labels change while the server is running.
+   *
+   * @param names - Label names as supplied by the caller
+   * @returns Node IDs of the labels that exist, in the caller's order
+   */
+  protected async resolveLabelIds(names?: string[]): Promise<string[]> {
+    if (!names || names.length === 0) return [];
+
+    const query = `
+      query GetLabelIds($owner: String!, $repo: String!) {
+        repository(owner: $owner, name: $repo) {
+          labels(first: 100) {
+            nodes { id name }
+          }
+        }
+      }
+    `;
+
+    interface LabelIdsResponse {
+      repository: { labels: { nodes: Array<{ id: string; name: string }> } } | null;
+    }
+
+    const response = await this.graphql<LabelIdsResponse>(query, {});
+    const nodes = response.repository?.labels?.nodes ?? [];
+    const idByName = new Map(nodes.map(node => [node.name, node.id]));
+
+    const unknown = names.filter(name => !idByName.has(name));
+    if (unknown.length > 0) {
+      this.logger.warn(
+        `Skipping labels that do not exist in ${this.owner}/${this.repo}: ${unknown.join(', ')}`
+      );
+    }
+
+    return names
+      .map(name => idByName.get(name))
+      .filter((id): id is string => id !== undefined);
+  }
+
+  /**
+   * Resolve assignee logins to user node IDs.
+   *
+   * Same problem as {@link resolveLabelIds}: `assigneeIds` is `[ID!]`, not logins.
+   * Logins that cannot be assigned in this repository are skipped with a warning.
+   *
+   * @param logins - GitHub logins as supplied by the caller
+   * @returns Node IDs of the assignable users, in the caller's order
+   */
+  protected async resolveAssigneeIds(logins?: string[]): Promise<string[]> {
+    if (!logins || logins.length === 0) return [];
+
+    const query = `
+      query GetAssigneeIds($owner: String!, $repo: String!) {
+        repository(owner: $owner, name: $repo) {
+          assignableUsers(first: 100) {
+            nodes { id login }
+          }
+        }
+      }
+    `;
+
+    interface AssigneeIdsResponse {
+      repository: { assignableUsers: { nodes: Array<{ id: string; login: string }> } } | null;
+    }
+
+    const response = await this.graphql<AssigneeIdsResponse>(query, {});
+    const nodes = response.repository?.assignableUsers?.nodes ?? [];
+    const idByLogin = new Map(nodes.map(node => [node.login, node.id]));
+
+    const unknown = logins.filter(login => !idByLogin.has(login));
+    if (unknown.length > 0) {
+      this.logger.warn(
+        `Skipping logins that cannot be assigned in ${this.owner}/${this.repo}: ${unknown.join(', ')}`
+      );
+    }
+
+    return logins
+      .map(login => idByLogin.get(login))
+      .filter((id): id is string => id !== undefined);
   }
 
   /**

--- a/src/infrastructure/github/repositories/GitHubIssueRepository.ts
+++ b/src/infrastructure/github/repositories/GitHubIssueRepository.ts
@@ -99,13 +99,20 @@ export class GitHubIssueRepository extends BaseGitHubRepository implements Issue
       }
     `;
 
+    // repositoryId/assigneeIds/labelIds are GraphQL IDs, not names.
+    const [repositoryId, assigneeIds, labelIds] = await Promise.all([
+      this.resolveRepositoryNodeId(),
+      this.resolveAssigneeIds(data.assignees),
+      this.resolveLabelIds(data.labels),
+    ]);
+
     const response = await this.graphql<CreateIssueResponse>(mutation, {
       input: {
-        repositoryId: this.repo,
+        repositoryId,
         title: data.title,
         body: data.description,
-        assigneeIds: data.assignees,
-        labelIds: data.labels,
+        assigneeIds,
+        labelIds,
         milestoneId: data.milestoneId,
       },
     });
@@ -142,14 +149,24 @@ export class GitHubIssueRepository extends BaseGitHubRepository implements Issue
       }
     `;
 
+    // Same ID-vs-name problem as create(). Note the undefined checks: an empty
+    // array means "remove all", so an omitted field must stay undefined ("leave
+    // as is") rather than being resolved into [].
+    const assigneeIds = data.assignees
+      ? await this.resolveAssigneeIds(data.assignees)
+      : undefined;
+    const labelIds = data.labels
+      ? await this.resolveLabelIds(data.labels)
+      : undefined;
+
     const response = await this.graphql<UpdateIssueResponse>(mutation, {
       input: {
         id,
         title: data.title,
         body: data.description,
         state: data.status === ResourceStatus.CLOSED ? "CLOSED" : "OPEN",
-        assigneeIds: data.assignees,
-        labelIds: data.labels,
+        assigneeIds,
+        labelIds,
         milestoneId: data.milestoneId,
       },
     });


### PR DESCRIPTION
Fixes #26.

`createIssue` and `updateIssue` pass human-readable names into GraphQL `ID` fields, so the API rejects the mutation:

```
Could not resolve to a node with the global id of 'priority:medium'
```

Three fields in the same input are affected:

```ts
repositoryId: this.repo,        // repo name, not a node ID
assigneeIds:  data.assignees,   // logins, not node IDs
labelIds:     data.labels,      // label names, not node IDs
```

Since `ToolSchemas` gives `priority` and `type` zod `.default()`s and `IssueService` appends them as `priority:<x>` / `type:<y>` labels, even a call that passes no labels carries two — so `create_issue` fails unconditionally, for every repository, and no argument combination avoids it.

## What this changes

Three resolvers on `BaseGitHubRepository`, next to the existing `resolveIssueNodeId()`:

| | cached | why |
|---|---|---|
| `resolveRepositoryNodeId()` | yes | a repository's node ID is stable |
| `resolveLabelIds()` | no | labels change while the server runs |
| `resolveAssigneeIds()` | no | collaborators change while the server runs |

`create()` resolves all three in parallel; `update()` resolves the two it needs.

**Unknown names are skipped with a warning, not created.** Creating them would silently alter a repository's label taxonomy as a side effect of writing an issue. This also makes the synthetic `priority:` / `type:` labels harmless in repos that don't define them.

**`update()` keeps `undefined` distinct from `[]`** — an empty array means "remove all", `undefined` means "leave unchanged", so an omitted field must not be resolved into `[]`.

## Tests

Two regression tests asserting the mutation input. They fail on `main`:

```
- "repositoryId": "R_repo123",
+ "repositoryId": "test-repo",
```

The existing suite mocked `graphql: jest.fn()` and never inspected its arguments, which is why this was invisible. The new tests route the mock by query name so the assertions can look at what actually reaches `createIssue`.

```
✓ should create an instance correctly
✓ passes node IDs — not names — to createIssue
✓ skips labels that do not exist instead of failing
```

`npm run build` is clean.

## Verified end-to-end

Built from this branch and driven over stdio against a real repository:

- **before:** `create_issue` → `Could not resolve to a node with the global id of '<repo>'`
- **after:** issue created, labels `backlog` + `doc` applied, a deliberately bogus label skipped with `Skipping labels that do not exist in <owner>/<repo>: …`

## Deliberately left alone

The `priority:` / `type:` label injection in `IssueService.createIssue()` (and its `zod` defaults) still happens — with this fix it is merely skipped when the labels don't exist. It's a separate design question: those look like project-board field values rather than labels, and today they cannot be turned off (`z.enum` rejects `""`). Happy to follow up in a second PR whichever way you prefer — drop the injection, or remove the `.default()`s so it becomes opt-in.

One related bug is also still open, same class: `data.labels || []` returns the caller's array and is then mutated with `.push`. Left out to keep this diff focused.
